### PR TITLE
Feat/rootaccess cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ docker-compose.prod.yml
 
 docker-compose.prod.yml
 backend/deploy_aws.sh
+.gemini/
+gha-creds-*.json

--- a/backend/internal/middleware/auth_middleware.go
+++ b/backend/internal/middleware/auth_middleware.go
@@ -11,10 +11,17 @@ import (
 
 func AuthMiddleware(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Strictly use cookies for authentication
+		// Support both cookies (frontend) and Authorization header (CLI)
 		tokenString, err := c.Cookie("auth_token")
-		
 		if err != nil || tokenString == "" {
+			// Check Authorization header
+			authHeader := c.GetHeader("Authorization")
+			if authHeader != "" && len(authHeader) > 7 && authHeader[:7] == "Bearer " {
+				tokenString = authHeader[7:]
+			}
+		}
+		
+		if tokenString == "" {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 			c.Abort()
 			return

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -344,6 +344,3 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 
 	return r
 }
-
-	return r
-}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,5 +1,5 @@
 {
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/((?!api|bin|install.sh).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
This pull request introduces several improvements to the CLI integration and API routing, enhances the frontend user experience, and updates build and deployment workflows for better flexibility and maintainability. The most significant changes are grouped below by theme:

**Backend API Routing and CLI Authentication:**

* Refactored API route registration in `routes.go` to use a helper function, ensuring all routes are accessible under both the root and `/api` prefixes. This improves compatibility with both web and CLI clients and reduces code duplication. Also, `/auth/me` now supports authentication via the `Authorization` header for CLI support. [[1]](diffhunk://#diff-8209e849d82b73db1b14973d6bff2b4d9fff200a0bbfd10386587fb4e705a89cR156-R212) [[2]](diffhunk://#diff-8209e849d82b73db1b14973d6bff2b4d9fff200a0bbfd10386587fb4e705a89cL221-R243) [[3]](diffhunk://#diff-8209e849d82b73db1b14973d6bff2b4d9fff200a0bbfd10386587fb4e705a89cR336-R343)

**CLI Build and Configuration:**

* Updated CLI build steps in GitHub Actions (`cli-release.yml` and `frontend-deploy.yml`) to inject the API URL at build time using a linker flag. The API URL is now configurable via a secret, with a default fallback, and always normalized to include the `/api` suffix. [[1]](diffhunk://#diff-2b580c9156212a6e8960aac74844fdfba9fda0f8a737f7e744082ca95729c50eL29-R42) [[2]](diffhunk://#diff-a9e1ff495f281c0fced65a796c69b5bcb77196eb9d20622b90a1837d260e637fL34-R45)
* Changed `DefaultBaseURL` in `cli/internal/config/config.go` from a constant to a variable, allowing it to be set at build time for improved deployment flexibility.

**Frontend Enhancements:**

* Added a new "CLI Integration" card to the account settings page, providing users with information and quick actions to install and log in to the CLI tool.
* Updated the frontend's `vercel.json` rewrite rules to exclude API, binary, and install script routes from being rewritten to `index.html`, ensuring proper routing for CLI downloads and API requests.